### PR TITLE
Update instance type to m6a.2xlarge

### DIFF
--- a/install-config.yaml
+++ b/install-config.yaml
@@ -11,7 +11,7 @@ controlPlane:
   hyperthreading: Enabled
   platform:
     aws:
-      type: m4.2xlarge
+      type: m6a.2xlarge
       rootVolume:
         size: 150
         type: gp3


### PR DESCRIPTION
Two generations newer and also cheaper spot pricing in a lot of regions & AZs