### PR TITLE
Minor sequencing nits

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,9 @@ Prerequisites:
 TOOL_VERSION=`curl https://raw.githubusercontent.com/jcjorel/ec2-spot-converter/master/VERSION.txt`
 curl https://raw.githubusercontent.com/jcjorel/ec2-spot-converter/master/releases/ec2-spot-converter-${TOOL_VERSION} -o ec2-spot-converter
 chmod u+x ec2-spot-converter
+export AWS_PROFILE=rhpds
+export AWS_REGION=ap-southeast-1
+ec2-spot-converter --generate-dynamodb-table
 ```
 
 ## Install and Adjust the SNO instance
@@ -28,17 +31,16 @@ chmod u+x ec2-spot-converter
 2. Install OpenShift
 
     ```bash
-    openshift-install create ignition-configs --dir=cluster
-    openshift-install create manifests --dir=cluster
+    export AWS_PROFILE=rhpds
+    export AWS_REGION=ap-southeast-1
     openshift-install create cluster --dir=cluster
     ```
 
 3. Export Env.Vars
 
     ```bash
-    export AWS_PROFILE=rhpds
-    export BASE_DOMAIN=sandbox.acme.com
     export CLUSTER_NAME=hivec
+    export BASE_DOMAIN=sandbox.acme.com
     ```
 
 4. Get our SNO InstanceId
@@ -53,7 +55,6 @@ chmod u+x ec2-spot-converter
 5. Convert SNO to SPOT
 
     ```bash
-    ec2-spot-converter --generate-dynamodb-table
     ec2-spot-converter --stop-instance --instance-id <instance_id>
     ```
 
@@ -82,6 +83,7 @@ chmod u+x ec2-spot-converter
 
     ```bash
     export AWS_PROFILE=rhpds
+    export AWS_REGION=ap-southeast-1
     export BASE_DOMAIN=sandbox.acme.com
     export CLUSTER_NAME=my-cluster
     export KUBEADMIN_PASSWORD=your-random-kubeadmin-password


### PR DESCRIPTION
1. Only need to create the dynamodb table once per region, moved that to pre-reqs
2. Need AWS_PROFILE for the installer to create install-config or create-cluster, moved that up to that step
3. Need AWS_REGION also for whatever was in install-config, added that explicitly to the env vars used
4. Unclear why they are calling make manifests or ignition-configs, simplified to only create-cluster